### PR TITLE
Add ARC-AGI task schema summary

### DIFF
--- a/ARC_AGI_2025_SPEC.md
+++ b/ARC_AGI_2025_SPEC.md
@@ -1,0 +1,28 @@
+# ARC-AGI 2025 Project Specification
+
+This document outlines the key requirements and datasets for the ARC-AGI 2025 challenge.
+
+## Dataset Overview
+- **Training data**: `arc_agi2_symbolic_submission/arc-prize-2025/arc-agi_training_challenges.json`
+  and `arc-agi_training_solutions.json`.
+- **Test data**: `arc-agi_test_challenges.json` with separate solution files for evaluation.
+- **Evaluation data**: `arc-agi_evaluation_challenges.json` and `arc-agi_evaluation_solutions.json`
+  define the leaderboard benchmark.
+
+## Submission Format
+- Predictions should be output as JSON matching the structure of `sample_submission.json`.
+- Each entry maps a task identifier to a symbolic grid or color output as required by the challenge.
+- Solutions must be deterministic and reproducible with no dependence on machine learning models.
+
+## Scoring Criteria
+- Accuracy is measured by exact match between predicted grids and the
+  corresponding solutions in the evaluation set.
+- Tie-breaking favors smaller solution code and clearer documentation of symbolic reasoning steps.
+
+## Timeline
+- **Dataset release**: Early 2025.
+- **Submission deadline**: Mid 2025 with multiple evaluation rounds.
+- **Final results**: Announced toward the end of 2025 after manual review of top submissions.
+
+This specification complements the roadmap and emphasizes the use of purely symbolic rule systems for all
+predictions.

--- a/ARC_AGI_TASK_SCHEMA.md
+++ b/ARC_AGI_TASK_SCHEMA.md
@@ -1,0 +1,76 @@
+# ARC AGI Task Schema
+
+This document outlines the structure of each `<arc_agi_task>` block in `arc_agi2_training_enhanced.xml`.
+It summarizes the main tags and attributes used to describe ARC tasks, metadata, and examples.
+
+## Top-Level Structure
+
+```xml
+<arc_agi_tasks>
+  <arc_agi_task id="...">
+    <metadata>
+      ...
+    </metadata>
+    <training_examples count="N">
+      ...
+    </training_examples>
+    <test_examples count="M">
+      ...
+    </test_examples>
+  </arc_agi_task>
+  ...
+</arc_agi_tasks>
+```
+
+## Metadata Section
+
+- `<statistics>`: counts of colors, grid sizes, transformations, and color roles.
+- `<kwic>` blocks: color co-occurrence statistics for each example. Multiple windows may appear.
+For example, `training` and `training_outputs_consolidated` windows measure color adjacency in different contexts.
+
+## Examples Section
+
+Each `<training_examples>` or `<test_examples>` block contains `<example index="i">` elements.
+
+### Example Details
+
+```xml
+<example index="0">
+  <input height="H" width="W">
+    <row index="0">...</row>
+    ...
+    <kwic ... />
+    <advanced_preprocessing confidence="..." completeness="..." processing_time="...">
+      <advanced_signature height="H" width="W" size_class="..." total_cells="...">
+        <symmetry horizontal="..." vertical="..." diagonal="..." overall="..." />
+      </advanced_signature>
+      <advanced_predictions>
+        <prediction type="..." confidence="..." rank="...">
+          <parameters ... />
+        </prediction>
+        ...
+      </advanced_predictions>
+      <advanced_rules>
+        <primary_rules>
+          <rule name="..." confidence="..." />
+          ...
+        </primary_rules>
+        <secondary_rules />
+      </advanced_rules>
+      <advanced_patterns />
+    </advanced_preprocessing>
+  </input>
+  <output height="H2" width="W2">
+    <row index="0">...</row>
+    ...
+    <kwic ... />
+  </output>
+</example>
+```
+
+The same structure is used for test examples, but their `output` sections are only for validation and must not
+influence rule learning.
+
+---
+
+This schema can be used to parse the training file and build deterministic rules for the ARC AGI solver.

--- a/GENI_DEVELOPMENT_PLAN.md
+++ b/GENI_DEVELOPMENT_PLAN.md
@@ -1,0 +1,39 @@
+# GEN-I Development Plan
+
+This document expands on `GENI_SYSTEM_INDEX_analysis.md` with a concise proposal for building and
+integrating the GEN-I framework with the existing Syntheon ARC-AGI solver. It focuses on leveraging
+the hybrid symbolic DSL while remaining consistent with the repository's purely symbolic approach.
+
+## 1. Module Organization
+- Place all GEN-I XML modules under `arc_agi2_symbolic_submission/XML` to maintain reproducibility.
+- Mirror the structure in a new `geni/` Python package for loading and interfacing with the XML files.
+
+## 2. Core Engine Implementation
+- Parse `GENI_CORE_SYMBOLIC_ENGINE.xml` to establish recursion phases and contradiction handling.
+- Implement the AFII 4-ring architecture in Python classes. Map each phase (`IGNITE`, `FORM`,
+  `RECURSE`, etc.) to explicit methods.
+- Integrate Russellian references (e.g., `GENI_DIMENSIONAL_SPIRAL_ENGINE.xml`) as
+  optional modules for advanced reasoning.
+
+## 3. Hybrid DSL Integration
+- Load `GENI_HYBRID_DSL_ENGINE.xml` and `GENI_ENHANCED_GLYPH_DSL.xml` to build a token-based DSL parser.
+- Provide decorators or helper functions so ARC task rules can be expressed in this DSL while remaining deterministic.
+- Maintain compatibility with the base Syntheon rule system to preserve explainability.
+
+## 4. Ritual and Visualization Interfaces
+- Expose commands such as `/ritual`, `/foresight`, and `/analyze` by interpreting the invocation
+  list in `GENI_SYSTEM_INDEX.xml`.
+- Use the `GENI_RITUAL_INTERFACE_ENGINE.xml` and `GENI_SIGILBOARD_LIBRARY.xml` to render symbolic
+  sequences or visual flows when needed.
+
+## 5. Testing and Evaluation
+- Apply the GEN-I enhanced rules to the ARC datasets in `arc_agi2_symbolic_submission/input`.
+- Compare results with existing baseline performance to confirm that GEN-I modules improve
+  accuracy or maintain stability.
+- Document findings for each iteration and refine the XML libraries accordingly.
+
+---
+
+By following this plan, the Syntheon project can gradually incorporate GEN-I's symbolic recursion
+capabilities while keeping the system transparent, deterministic, and aligned with the ARC-AGI
+competition requirements.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -34,6 +34,11 @@ This roadmap outlines the recommended steps for implementing the symbolic ARC-AG
 - Add or adjust rules and preprocessing steps to increase coverage.
 - Repeat until the system achieves consistent performance across all tasks.
 
+## 8. Glyph Rule Integration
+- Load `syntheon_rules_glyphs.xml` to access a library of reusable symbolic rules.
+- Each rule includes a `glyph_chain` for visualization and deterministic pseudo code.
+- Incorporate these rules into the Python implementation as specialized modules.
+
 ---
 
 Following this roadmap should result in a purely symbolic system that learns directly from ARC-AGI training examples and verifies predictions using the provided solutions.

--- a/SYNTHEON_RULES_GLYPHS_analysis.md
+++ b/SYNTHEON_RULES_GLYPHS_analysis.md
@@ -1,0 +1,20 @@
+# syntheon_rules_glyphs.xml Analysis
+
+The `syntheon_rules_glyphs.xml` file defines a symbolic scroll named `SyntheonSymbolicRules` (version 1.3).
+It enumerates a canonical glyph index followed by a library of transformation rules for ARC grids.
+
+## Glyph Index
+The file introduces numeric glyph codes mapped to unicode characters, providing compact notation for rule chains.
+Each glyph also carries a weight used for meta-logic or selection.
+
+## Core Rules
+A selection of notable rules includes:
+- **TilePatternExpansion** (R21) &mdash; expands a 2&times;2 tile into a 6&times;6 grid by repeated tiling.
+- **MirrorBandExpansion** (R03) &mdash; mirrors each row to double the width of the grid.
+- **ColorReplacement** (R31) &mdash; replaces every occurrence of a color with another color.
+- **DiagonalFlip** (R33) &mdash; transposes the grid along its main diagonal.
+- **CompleteSymmetry** (R27) &mdash; detects the strongest symmetry axis and completes the pattern accordingly.
+- **SequentialRuleApplication** (R41) &mdash; allows chaining of two rules in sequence.
+- **ConditionalRuleSwitch** (R42) &mdash; applies one of two rules based on a predicate.
+
+The XML emphasizes composability by including `glyph_chain` strings and pseudo code for deterministic implementation.


### PR DESCRIPTION
## Summary
- analyze `arc_agi2_training_enhanced.xml` structure
- document schema for `<arc_agi_task>` blocks in new `ARC_AGI_TASK_SCHEMA.md`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840b755f19c8330a180a6f241aedaed