### PR TITLE
Fix line lengths in docs

### DIFF
--- a/GENI_SYSTEM_INDEX_analysis.md
+++ b/GENI_SYSTEM_INDEX_analysis.md
@@ -1,11 +1,14 @@
 # GENI_SYSTEM_INDEX Analysis
 
-The `GENI_SYSTEM_INDEX.xml` file is located in `arc_agi2_symbolic_submission/XML/`. It describes the structure of **GEN-I** (Symbolic Recursion Intelligence) and references numerous engines and libraries for a hybrid symbolic DSL architecture.
+The `GENI_SYSTEM_INDEX.xml` file is located in `arc_agi2_symbolic_submission/XML/`. It describes the structure
+of **GEN-I** (Symbolic Recursion Intelligence) and references numerous engines and libraries for a hybrid symbolic
+DSL architecture.
 
 ## GEN-I Overview
 
 - **Description**: System prompt for GEN-I &mdash; symbolic recursion intelligence with hybrid DSL architecture.
-- **Architecture**: AFII recursive design featuring spiral compression, Arkè glyph grammar, Russellian physics, Tarot symbolism, and a hybrid execution framework.
+- **Architecture**: AFII recursive design featuring spiral compression, Arkè glyph grammar, Russellian physics,
+  Tarot symbolism, and a hybrid execution framework.
 - **Version**: `v5.0.0-Syntheon-Hybrid`.
 
 ### Core Files
@@ -17,16 +20,20 @@ GENI_SYSTEM_INDEX lists multiple components, including:
 - Many additional engines covering foresight, alchemical cycles, and spiral modeling.
 
 ### Expansion Files
-These extend the core with output rendering, symbolic libraries, ritual templates, astrological overlays, and transformation themes.
+These extend the core with output rendering, symbolic libraries, ritual templates,
+astrological overlays, and transformation themes.
 
 ### Russellian References
-Models that map Walter Russell's dimensional physics into the recursion framework, such as `GENI_PERIODIC_TABLE_OF_18_DIMENSIONS.xml` and `GENI_DIMENSIONAL_SPIRAL_ENGINE.xml`.
+Models that map Walter Russell's dimensional physics into the recursion framework,
+such as `GENI_PERIODIC_TABLE_OF_18_DIMENSIONS.xml` and `GENI_DIMENSIONAL_SPIRAL_ENGINE.xml`.
 
 ### Hybrid DSL Architecture
-Defines a unified DSL engine with enhanced glyph syntax, adaptive keyword-in-context weighting, multi-language rule repositories, and meta-rule constructs.
+Defines a unified DSL engine with enhanced glyph syntax, adaptive keyword-in-context weighting,
+multi-language rule repositories, and meta-rule constructs.
 
 ### Invocation Commands
-The index lists commands like `/help`, `/ritual`, `/analyze`, `/foresight`, and `/hybrid.optimize`, indicating supported operations within the GEN-I environment.
+The index lists commands like `/help`, `/ritual`, `/analyze`, `/foresight`, and `/hybrid.optimize`,
+indicating supported operations within the GEN-I environment.
 
 ## Plan for Integrating GEN-I with ARC-AGI
 
@@ -34,7 +41,8 @@ The index lists commands like `/help`, `/ritual`, `/analyze`, `/foresight`, and 
    - Import all GEN-I XML modules into Syntheon's processing pipeline.
    - Maintain version control under `arc_agi2_symbolic_submission/XML` for reproducibility.
 2. **Map symbolic engines to ARC tasks**
-   - Align recursion engines (e.g., `GENI_CORE_SYMBOLIC_ENGINE`, `GENI_FORESIGHT_ENGINE`) with ARC task preprocessing and rule generation.
+   - Align recursion engines (e.g., `GENI_CORE_SYMBOLIC_ENGINE`, `GENI_FORESIGHT_ENGINE`)
+     with ARC task preprocessing and rule generation.
    - Utilize Russellian references to enrich pattern detection logic where relevant.
 3. **Extend Syntheon DSL**
    - Incorporate the Hybrid DSL components so that symbolic rules can reference GEN-I glyphs and meta-rules.
@@ -43,4 +51,5 @@ The index lists commands like `/help`, `/ritual`, `/analyze`, `/foresight`, and 
    - Test integrated functionality against the existing ARC datasets in `arc_agi2_symbolic_submission/input`.
    - Document improvements and adjust GEN-I modules as needed.
 
-The provided index offers a comprehensive blueprint for GEN-I. Incorporating these modules will deepen Syntheon's symbolic reasoning capabilities and facilitate development of the ARC‑AGI solution.
+The provided index offers a comprehensive blueprint for GEN-I. Incorporating these modules
+will deepen Syntheon's symbolic reasoning capabilities and facilitate development of the ARC‑AGI solution.

--- a/OVERVIEW.md
+++ b/OVERVIEW.md
@@ -1,1 +1,5 @@
-The repository contains the **SyntheonResearch** project, which implements a purely symbolic approach for solving ARC-AGI tasks. According to its README, Syntheon uses deterministic reasoning and task-specific rule learning without relying on language models. Key principles include advanced preprocessing with structured XML metadata, multi-tier symbolic rules, size-class heuristics, and symmetry-guided transformations. The repository also includes ARC-AGI training and evaluation data under `arc_agi2_symbolic_submission/arc-prize-2025`.
+The repository contains the **SyntheonResearch** project, which implements a purely symbolic approach for solving
+ARC-AGI tasks. According to its README, Syntheon uses deterministic reasoning and task-specific rule learning without
+relying on language models. Key principles include advanced preprocessing with structured XML metadata, multi-tier
+symbolic rules, size-class heuristics, and symmetry-guided transformations. The repository also includes ARC-AGI
+training and evaluation data under `arc_agi2_symbolic_submission/arc-prize-2025`.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,7 @@
 # Syntheon Python Implementation Roadmap
 
-This roadmap outlines the recommended steps for implementing the symbolic ARC-AGI solver in Python. It expands on the core principles described in the README.
+This roadmap outlines the recommended steps for implementing the symbolic ARC-AGI solver in Python.
+It expands on the core principles described in the README.
 
 ## 1. Environment Setup
 - Use Python 3.x with standard libraries (e.g., `xml.etree.ElementTree`, `numpy` for grid data structures).
@@ -41,4 +42,5 @@ This roadmap outlines the recommended steps for implementing the symbolic ARC-AG
 
 ---
 
-Following this roadmap should result in a purely symbolic system that learns directly from ARC-AGI training examples and verifies predictions using the provided solutions.
+Following this roadmap should result in a purely symbolic system that learns directly from ARC-AGI training examples
+and verifies predictions using the provided solutions.


### PR DESCRIPTION
## Summary
- reflow lines in `ROADMAP.md`
- shorten `OVERVIEW.md` to multiple lines
- rewrap `GENI_SYSTEM_INDEX_analysis.md`

## Testing
- `awk 'length($0)>120'` on all updated markdown files

------
https://chatgpt.com/codex/tasks/task_e_6840c4b0a90c8330bfe73a1372f75a3d