### PR TITLE
Add learning features to rule engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ predictions suitable for rigorous evaluation and competition-grade benchmarks.
 
   * Each task includes:
 
-    * `<training_examples>` — used for symbolic rule extraction
+    * `<training_examples>` — used for symbolic rule extraction and as multi-shot
+      context when prompting the LLM-based solver
     * `<test_examples>` — used *only* for output validation
 
 ---

--- a/src/rule_engine.py
+++ b/src/rule_engine.py
@@ -15,7 +15,10 @@ Example
 
 from __future__ import annotations
 
-from typing import Dict, List
+import xml.etree.ElementTree as ET
+from typing import Dict, List, Optional
+
+from ingest import Example, Task
 
 
 class Rule:
@@ -69,3 +72,125 @@ def register_primary(name: str, rule: Rule) -> None:
 def register_secondary(name: str, rule: Rule) -> None:
     """Register a rule as secondary."""
     SECONDARY_RULES[name] = rule
+
+
+class RuleEngine:
+    """Simple engine capable of loading and applying symbolic rules."""
+
+    def __init__(self) -> None:
+        self.registry: Dict[str, Rule] = {}
+        self.metadata: Dict[str, Dict[str, str]] = {}
+
+    # ------------------------------------------------------------------
+    # Registration and lookup
+    # ------------------------------------------------------------------
+    def register(self, name: str, rule: Rule) -> None:
+        """Register a rule implementation."""
+        self.registry[name] = rule
+
+    def available_rules(self) -> List[str]:  # pragma: no cover - simple helper
+        return sorted(self.registry)
+
+    # ------------------------------------------------------------------
+    # XML loading
+    # ------------------------------------------------------------------
+    def load_rules_metadata(self, xml_path: str) -> None:
+        """Parse an XML rule scroll and store metadata."""
+        tree = ET.parse(xml_path)
+        root = tree.getroot()
+        for rule_el in root.findall("rule"):
+            name = rule_el.get("name", "")
+            self.metadata[name] = {
+                "id": rule_el.get("id", ""),
+                "desc": rule_el.findtext("description", default=""),
+                "cond": rule_el.findtext("condition", default=""),
+            }
+
+    # ------------------------------------------------------------------
+    # Execution
+    # ------------------------------------------------------------------
+    def apply(self, name: str, grid: List[List[int]], **kwargs) -> List[List[int]]:
+        if name not in self.registry:
+            raise KeyError(f"Unknown rule: {name}")
+        rule = self.registry[name]
+        # Rules may choose to ignore kwargs
+        return rule.apply(grid, **kwargs) if hasattr(rule, "apply") else rule(grid, **kwargs)
+
+    # ------------------------------------------------------------------
+    # Learning and solving
+    # ------------------------------------------------------------------
+    def learn_rule(
+        self, examples: List[Example], max_chain_length: int = 1
+    ) -> Optional[Rule]:
+        """Find a rule or rule chain that explains all training examples."""
+
+        # Search single rules first
+        for rule in self.registry.values():
+            if all(rule.apply(ex.input_grid) == ex.output_grid for ex in examples):
+                return rule
+
+        # Optionally search chains of length two
+        if max_chain_length >= 2:
+            for r1 in self.registry.values():
+                for r2 in self.registry.values():
+                    chain = RuleChain(r1, r2)
+                    if all(chain.apply(ex.input_grid) == ex.output_grid for ex in examples):
+                        return chain
+
+        return None
+
+    def solve_task(self, task: Task, max_chain_length: int = 1) -> List[List[List[int]]]:
+        """Learn from the task's training examples and predict test outputs."""
+
+        rule = self.learn_rule(task.training, max_chain_length)
+        results = []
+        for ex in task.tests:
+            grid = ex.input_grid
+            if rule is not None:
+                grid = rule.apply(grid)
+            results.append(grid)
+        return results
+
+
+# --------------------------- Example primitives ---------------------------
+class DiagonalFlipRule(Rule):
+    """Transpose the grid along its main diagonal."""
+
+    def apply(self, grid: List[List[int]]) -> List[List[int]]:
+        return [list(row) for row in zip(*grid)]
+
+
+class HorizontalMirrorRule(Rule):
+    """Mirror the grid horizontally."""
+
+    def apply(self, grid: List[List[int]]) -> List[List[int]]:
+        return [list(reversed(row)) for row in grid]
+
+
+class Rotate90Rule(Rule):
+    """Rotate the grid 90 degrees clockwise."""
+
+    def apply(self, grid: List[List[int]]) -> List[List[int]]:
+        size = len(grid)
+        return [
+            [grid[size - j - 1][i] for j in range(size)]
+            for i in range(size)
+        ]
+
+
+class RuleChain(Rule):
+    """Apply a sequence of rules in order."""
+
+    def __init__(self, *rules: Rule) -> None:
+        self.rules = list(rules)
+
+    def apply(self, grid: List[List[int]]) -> List[List[int]]:
+        result = grid
+        for rule in self.rules:
+            result = rule.apply(result)
+        return result
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return f"RuleChain({', '.join(repr(r) for r in self.rules)})"
+
+

--- a/tests/test_rule_engine.py
+++ b/tests/test_rule_engine.py
@@ -1,4 +1,12 @@
-from rule_engine import ColorReplacementRule, register_primary, PRIMARY_RULES
+from rule_engine import (
+    ColorReplacementRule,
+    DiagonalFlipRule,
+    RuleChain,
+    RuleEngine,
+    register_primary,
+    PRIMARY_RULES,
+)
+from ingest import Example, Task
 
 
 def test_color_replacement():
@@ -11,3 +19,30 @@ def test_register_primary():
     rule = ColorReplacementRule(0, 1)
     register_primary("zero_to_one", rule)
     assert "zero_to_one" in PRIMARY_RULES
+
+
+def test_rule_chain():
+    flip = DiagonalFlipRule()
+    replace = ColorReplacementRule(1, 9)
+    chain = RuleChain(flip, replace)
+    grid = [[1, 2], [3, 1]]
+    assert chain.apply(grid) == [[9, 3], [2, 9]]
+
+
+def test_learn_rule():
+    engine = RuleEngine()
+    engine.register("rep", ColorReplacementRule(1, 2))
+    examples = [Example(index=0, input_grid=[[1]], output_grid=[[2]])]
+    rule = engine.learn_rule(examples)
+    assert isinstance(rule, ColorReplacementRule)
+
+
+def test_solve_task_with_chain():
+    engine = RuleEngine()
+    engine.register("flip", DiagonalFlipRule())
+    engine.register("rep", ColorReplacementRule(1, 9))
+    train = [Example(index=0, input_grid=[[1, 2], [3, 1]], output_grid=[[9, 3], [2, 9]])]
+    tests = [Example(index=0, input_grid=[[1, 4], [5, 1]], output_grid=[[9, 5], [4, 9]])]
+    task = Task(id="t", metadata_xml="", training=train, tests=tests)
+    preds = engine.solve_task(task, max_chain_length=2)
+    assert preds == [[[9, 5], [4, 9]]]


### PR DESCRIPTION
## Summary
- support rule learning and simple task solving
- import training examples as multi-shot context
- extend tests for learning and solving

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68412aa8dd948330a6f7b5d15f86225c